### PR TITLE
Remove PyPy special cases

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,11 +20,11 @@ trigger:
 
 jobs:
   - template: azure-run-tox-env.yml
-    parameters: {tox: fix_lint, python: 3.7}
+    parameters: {tox: fix_lint, python: '3.7'}
   - template: azure-run-tox-env.yml
-    parameters: {tox: docs, python: 3.7}
+    parameters: {tox: docs, python: '3.7'}
   - template: azure-run-tox-env.yml
-    parameters: {tox: package_description, python: 3.7}
+    parameters: {tox: package_description, python: '3.7'}
 
   - template: azure-run-tox-env.yml
     parameters: {tox: pypy, python: pypy, os: linux}
@@ -32,29 +32,29 @@ jobs:
     parameters: {tox: pypy3, python: pypy3, os: linux}
 
   - template: azure-run-tox-env.yml
-    parameters: {tox: py37, python: 3.7, os: windows}
+    parameters: {tox: py37, python: '3.7', os: windows}
   - template: azure-run-tox-env.yml
-    parameters: {tox: py36, python: 3.6, os: windows}
+    parameters: {tox: py36, python: '3.6', os: windows}
   - template: azure-run-tox-env.yml
-    parameters: {tox: py35, python: 3.5, os: windows}
+    parameters: {tox: py35, python: '3.5', os: windows}
   - template: azure-run-tox-env.yml
-    parameters: {tox: py34, python: 3.4, os: windows}
+    parameters: {tox: py34, python: '3.4', os: windows}
   - template: azure-run-tox-env.yml
-    parameters: {tox: py27, python: 2.7, os: windows}
+    parameters: {tox: py27, python: '2.7', os: windows}
 
   - template: azure-run-tox-env.yml
-    parameters: {tox: py37, python: 3.7, os: linux}
+    parameters: {tox: py37, python: '3.7', os: linux}
   - template: azure-run-tox-env.yml
-    parameters: {tox: py36, python: 3.6, os: linux}
+    parameters: {tox: py36, python: '3.6', os: linux}
   - template: azure-run-tox-env.yml
-    parameters: {tox: py35, python: 3.5, os: linux}
+    parameters: {tox: py35, python: '3.5', os: linux}
   - template: azure-run-tox-env.yml
-    parameters: {tox: py34, python: 3.4, os: linux}
+    parameters: {tox: py34, python: '3.4', os: linux}
   - template: azure-run-tox-env.yml
-    parameters: {tox: py27, python: 2.7, os: linux}
+    parameters: {tox: py27, python: '2.7', os: linux}
 
   - template: azure-run-tox-env.yml
-    parameters: {tox: py36, python: 3.6, os: macOs}
+    parameters: {tox: py36, python: '3.6', os: macOs}
 
   - job: report_coverage
     pool: {vmImage: 'Ubuntu 16.04'}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
     parameters: {tox: package_description, python: '3.7'}
 
   - template: azure-run-tox-env.yml
-    parameters: {tox: pypy, python: pypy, os: linux}
+    parameters: {tox: pypy, python: pypy2, os: linux}
   - template: azure-run-tox-env.yml
     parameters: {tox: pypy3, python: pypy3, os: linux}
 

--- a/azure-run-tox-env.yml
+++ b/azure-run-tox-env.yml
@@ -13,21 +13,14 @@ jobs:
     ${{ if eq(parameters.os, 'linux') }}:
       vmImage: "Ubuntu 16.04"
 
-  variables:
-    ${{ if in(parameters.python, 'pypy', 'pypy3') }}:
-      python: ${{ parameters.python }}
-    ${{ if notIn(parameters.python, 'pypy', 'pypy3') }}:
-      python: "python"
-
   steps:
   # ensure the required Python versions are available
-  - ${{ if notIn(parameters.python, 'pypy', 'pypy3') }}:
-    - task: UsePythonVersion@0
-      displayName: setup python
-      inputs:
-        versionSpec: ${{ parameters.python }}
+  - task: UsePythonVersion@0
+    displayName: setup python
+    inputs:
+      versionSpec: ${{ parameters.python }}
 
-  - script: "$(python) -c \"import sys; print(sys.version); print(sys.executable)\""
+  - script: "python -c \"import sys; print(sys.version); print(sys.executable)\""
     displayName: show python information
 
   - script: "python -m pip install -U pip setuptools --user -v"


### PR DESCRIPTION
Hello, PM from Azure Pipelines here. We've added PyPy and PyPy3 as valid targets for the `UsePythonTask`, so you no longer have to special-case them.