### PR TITLE
Exclude dependabot and pre-commit ci from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos