### PR TITLE
🔧 chore: add Python 3.14 classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
@@ -94,7 +95,7 @@ write-changes = true
 count = true
 
 [tool.pyproject-fmt]
-max_supported_python = "3.13"
+max_supported_python = "3.14"
 
 [tool.coverage]
 run.branch = true


### PR DESCRIPTION
The project already tests against Python 3.14 in CI and configures `tool.ty` with `python-version = "3.14"`, but the trove classifier and `pyproject-fmt` max version were still at 3.13. This brings the metadata in line with what's actually supported.